### PR TITLE
Add University Controller + Tests

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityController.java
@@ -2,8 +2,42 @@ package edu.ucsb.cs156.spring.backenddemo.controllers;
 
 import org.springframework.web.bind.annotation.RestController;
 
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+
+@Tag(name="University Query from Hipolabs")
+@Slf4j
 @RestController
+@RequestMapping("/api/university")
 public class UniversityController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    UniversityQueryService universityQueryService;
+    @Operation(summary = "Get university names that match a search string", description = "JSON return format example here: http://universities.hipolabs.com/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getUniversity(
+        @Parameter(name="name", description="A University Name", example="Stanford") @RequestParam String name
+    ) throws JsonProcessingException {
+        log.info("getUniversity: name={}", name);
+        String result = universityQueryService.getJSON(name);
+        return ResponseEntity.ok().body(result);
+    }
+
+
+
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryService.java
@@ -2,11 +2,31 @@ package edu.ucsb.cs156.spring.backenddemo.services;
 
 
 
+import lombok.extern.slf4j.Slf4j;
+
+
+
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import org.springframework.web.client.RestTemplate;
 
 import lombok.extern.slf4j.Slf4j;
+
+// import java.net.http.HttpHeaders;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+
+
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
 
@@ -17,16 +37,27 @@ import org.springframework.web.client.HttpClientErrorException;
 @Service
 public class UniversityQueryService {
 
-
+    ObjectMapper mapper = new ObjectMapper();
     private final RestTemplate restTemplate;
 
     public UniversityQueryService(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
     }
 
-    public static final String ENDPOINT = "";
+    public static final String ENDPOINT = "http://universities.hipolabs.com/search?name={name}";
 
     public String getJSON(String name) throws HttpClientErrorException {
-       return "";
+        log.info("name={}", name);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> uriVariables = Map.of("name", name);
+
+        HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+        ResponseEntity<String> re = restTemplate.exchange(ENDPOINT, HttpMethod.GET, entity, String.class,
+                uriVariables);
+        return re.getBody();
     }
 }

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/UniversityControllerTests.java
@@ -1,0 +1,62 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.UniversityQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.http.HttpHeaders;
+
+
+@WebMvcTest(value = UniversityController.class)
+public class UniversityControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    UniversityQueryService mockUniversityQueryService;
+
+    @Test
+    public void test_getUniversity() throws Exception {
+    
+        String fakeJsonResult="{ \"fake\" : \"result\" }";
+        String name = "Stanford";
+        when(mockUniversityQueryService.getJSON(eq(name))).thenReturn(fakeJsonResult);
+
+        String url = String.format("/api/university/get?name=%s",name);
+
+        MvcResult response = mockMvc
+            .perform( get(url).contentType("application/json"))
+            .andExpect(status().isOk()).andReturn();
+
+        String responseString = response.getResponse().getContentAsString();
+
+        assertEquals(fakeJsonResult, responseString);
+    }
+
+
+
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/services/UniversityQueryServiceTests.java
@@ -1,0 +1,47 @@
+package edu.ucsb.cs156.spring.backenddemo.services;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+
+
+
+@RestClientTest(UniversityQueryService.class)
+public class UniversityQueryServiceTests {
+    @Autowired
+    private MockRestServiceServer mockRestServiceServer;
+
+    @Autowired
+    private UniversityQueryService universityQueryService;
+
+    @Test
+    public void test_getJSON() {
+
+        String name = "Stanford";
+        String expectedURL = UniversityQueryService.ENDPOINT.replace("{name}", name);
+
+
+    // "state-province": null, "country": "United States", "domains": ["stanford.edu"],
+    // "web_pages":["http://www.stanford.edu/"], "alpha_two_code": "US", "name": "Stanford University"}
+                
+
+        String fakeJsonResult = "{ \"fake\" : \"result\" }";
+
+        this.mockRestServiceServer.expect(requestTo(expectedURL))
+                .andExpect(header("Accept", MediaType.APPLICATION_JSON.toString()))
+                .andExpect(header("Content-Type", MediaType.APPLICATION_JSON.toString()))
+                .andRespond(withSuccess(fakeJsonResult, MediaType.APPLICATION_JSON));
+
+        String actualResult = universityQueryService.getJSON(name);
+        assertEquals(fakeJsonResult, actualResult);
+    }
+    
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/university/get` that can be used to get information about a university. 

Closes #15 